### PR TITLE
fix: IoSTIndex link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ other events from video games to control sex hardware supported by the
 
 Toys that support vibration or rotation are supported by the GHR:
 
-- [List of supported vibrating toys](https://iostindex.com/?filter0Features=OutputsVibrators&filter1ButtplugSupport=1)
-- [List of supported rotating toys](https://iostindex.com/?filter0Features=OutputsRotators&filter1ButtplugSupport=1)
+- [List of supported vibrating toys](https://iostindex.com/?filter0Features=OutputsVibrators&filter1ButtplugSupport=4)
+- [List of supported rotating toys](https://iostindex.com/?filter0Features=OutputsRotators&filter1ButtplugSupport=4)
 
 Releases can be downloaded [on the releases page.](https://github.com/intiface/intiface-game-haptics-router/releases)
 


### PR DESCRIPTION
The links were pointing at the c# support filter, but GHR now uses rs