### PR TITLE
Vibration fade

### DIFF
--- a/IntifaceGameHapticsRouter/App.config
+++ b/IntifaceGameHapticsRouter/App.config
@@ -50,6 +50,12 @@
       <setting name="PacketTimingGapInMS" serializeAs="String">
         <value>100</value>
       </setting>
+      <setting name="VibrationFadeMs" serializeAs="String">
+        <value>0</value>
+      </setting>
+      <setting name="DirectDualSenseRumble" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="UseEmbedded" serializeAs="String">
         <value>True</value>
       </setting>

--- a/IntifaceGameHapticsRouter/DualSenseRumble.cs
+++ b/IntifaceGameHapticsRouter/DualSenseRumble.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace IntifaceGameHapticsRouter
+{
+    // USB-only DualSense rumble writer. Prototype — BT requires the 0x31 report with CRC32 and is not implemented here.
+    internal sealed class DualSenseRumble : IDisposable
+    {
+        private const ushort SonyVid = 0x054C;
+        private const ushort DualSensePid = 0x0CE6;
+        private const ushort DualSenseEdgePid = 0x0DF2;
+
+        // USB DualSense output report total length including the report ID byte.
+        private const int UsbOutputReportSize = 48;
+
+        private readonly object _lock = new object();
+        private SafeFileHandle _handle;
+        private byte[] _buffer;
+
+        public bool IsOpen
+        {
+            get
+            {
+                var h = _handle;
+                return h != null && !h.IsInvalid && !h.IsClosed;
+            }
+        }
+
+        public string DevicePath { get; private set; }
+
+        // Attempt to enumerate and open a USB-mode DualSense. Returns true on success.
+        public bool TryOpen()
+        {
+            Close();
+            var path = FindDualSensePath();
+            if (path == null)
+            {
+                return false;
+            }
+
+            var handle = NativeMethods.CreateFile(
+                path,
+                NativeMethods.GenericWrite,
+                NativeMethods.FileShareRead | NativeMethods.FileShareWrite,
+                IntPtr.Zero,
+                NativeMethods.OpenExisting,
+                0,
+                IntPtr.Zero);
+
+            if (handle.IsInvalid)
+            {
+                handle.Dispose();
+                return false;
+            }
+
+            _handle = handle;
+            DevicePath = path;
+            _buffer = new byte[UsbOutputReportSize];
+            return true;
+        }
+
+        // Writes a USB output report 0x02 with the given motor levels (0..255).
+        // strongMotor = low-frequency rumble (XInput LeftMotor equivalent).
+        // weakMotor   = high-frequency rumble (XInput RightMotor equivalent).
+        public bool SetRumble(byte strongMotor, byte weakMotor)
+        {
+            if (!IsOpen)
+            {
+                return false;
+            }
+
+            lock (_lock)
+            {
+                if (!IsOpen)
+                {
+                    return false;
+                }
+
+                Array.Clear(_buffer, 0, _buffer.Length);
+                _buffer[0] = 0x02; // USB output report id
+                _buffer[1] = 0xFF; // valid_flag0: update everything (rumble, triggers, etc.)
+                _buffer[2] = 0xF7; // valid_flag1: update LEDs / mute LEDs / mic, leave lightbar control untouched
+                _buffer[3] = weakMotor;   // rumble_right (small motor)
+                _buffer[4] = strongMotor; // rumble_left (large motor)
+
+                if (!NativeMethods.WriteFile(_handle, _buffer, (uint)_buffer.Length, out _, IntPtr.Zero))
+                {
+                    // Likely a disconnect or another process took exclusive access. Drop the handle so a
+                    // future TryOpen can re-enumerate.
+                    CloseLocked();
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        public void Close()
+        {
+            lock (_lock)
+            {
+                CloseLocked();
+            }
+        }
+
+        private void CloseLocked()
+        {
+            _handle?.Dispose();
+            _handle = null;
+            DevicePath = null;
+            _buffer = null;
+        }
+
+        public void Dispose() => Close();
+
+        private static string FindDualSensePath()
+        {
+            NativeMethods.HidD_GetHidGuid(out var hidGuid);
+
+            var devSet = NativeMethods.SetupDiGetClassDevs(
+                ref hidGuid,
+                null,
+                IntPtr.Zero,
+                NativeMethods.DIGCF_PRESENT | NativeMethods.DIGCF_DEVICEINTERFACE);
+
+            if (devSet == new IntPtr(-1))
+            {
+                return null;
+            }
+
+            try
+            {
+                var iface = new NativeMethods.SP_DEVICE_INTERFACE_DATA();
+                iface.cbSize = Marshal.SizeOf(typeof(NativeMethods.SP_DEVICE_INTERFACE_DATA));
+
+                for (int idx = 0; NativeMethods.SetupDiEnumDeviceInterfaces(devSet, IntPtr.Zero, ref hidGuid, idx, ref iface); idx++)
+                {
+                    var path = GetInterfaceDetailPath(devSet, ref iface);
+                    if (path == null)
+                    {
+                        continue;
+                    }
+
+                    if (IsDualSense(path, out var isUsb) && isUsb)
+                    {
+                        return path;
+                    }
+                }
+            }
+            finally
+            {
+                NativeMethods.SetupDiDestroyDeviceInfoList(devSet);
+            }
+
+            return null;
+        }
+
+        private static string GetInterfaceDetailPath(IntPtr devSet, ref NativeMethods.SP_DEVICE_INTERFACE_DATA iface)
+        {
+            NativeMethods.SetupDiGetDeviceInterfaceDetail(devSet, ref iface, IntPtr.Zero, 0, out var requiredSize, IntPtr.Zero);
+            if (requiredSize <= 0)
+            {
+                return null;
+            }
+
+            var buffer = Marshal.AllocHGlobal(requiredSize);
+            try
+            {
+                // SP_DEVICE_INTERFACE_DETAIL_DATA: first field is DWORD cbSize.
+                // On x64 the struct is 8-byte aligned so cbSize is "5 + 3 padding"; on x86 it's 5.
+                Marshal.WriteInt32(buffer, IntPtr.Size == 8 ? 8 : (4 + Marshal.SystemDefaultCharSize));
+
+                if (!NativeMethods.SetupDiGetDeviceInterfaceDetail(devSet, ref iface, buffer, requiredSize, out _, IntPtr.Zero))
+                {
+                    return null;
+                }
+
+                // Path string starts immediately after the cbSize field (4 bytes).
+                var pathPtr = new IntPtr(buffer.ToInt64() + 4);
+                return Marshal.PtrToStringAuto(pathPtr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        private static bool IsDualSense(string path, out bool isUsb)
+        {
+            isUsb = false;
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            var handle = NativeMethods.CreateFile(
+                path,
+                0,
+                NativeMethods.FileShareRead | NativeMethods.FileShareWrite,
+                IntPtr.Zero,
+                NativeMethods.OpenExisting,
+                0,
+                IntPtr.Zero);
+
+            if (handle.IsInvalid)
+            {
+                handle.Dispose();
+                return false;
+            }
+
+            try
+            {
+                var attr = new NativeMethods.HIDD_ATTRIBUTES();
+                attr.Size = Marshal.SizeOf(typeof(NativeMethods.HIDD_ATTRIBUTES));
+                if (!NativeMethods.HidD_GetAttributes(handle, ref attr))
+                {
+                    return false;
+                }
+
+                if (attr.VendorID != SonyVid)
+                {
+                    return false;
+                }
+                if (attr.ProductID != DualSensePid && attr.ProductID != DualSenseEdgePid)
+                {
+                    return false;
+                }
+
+                // BT enumerations expose multiple interface paths; we want the one with the small USB-style
+                // output report. Use HidP caps to decide. Path-string heuristics (e.g. "_bthenum") are unreliable.
+                if (!NativeMethods.HidD_GetPreparsedData(handle, out var preparsed) || preparsed == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                try
+                {
+                    if (NativeMethods.HidP_GetCaps(preparsed, out var caps) != NativeMethods.HIDP_STATUS_SUCCESS)
+                    {
+                        return false;
+                    }
+
+                    // USB DualSense reports 64-byte output (we only write 48 of it).
+                    // BT DualSense reports 547+ byte output and needs the 0x31 report with CRC32 — not handled here.
+                    isUsb = caps.OutputReportByteLength <= 64;
+                    return true;
+                }
+                finally
+                {
+                    NativeMethods.HidD_FreePreparsedData(preparsed);
+                }
+            }
+            finally
+            {
+                handle.Dispose();
+            }
+        }
+
+        private static class NativeMethods
+        {
+            public const uint GenericRead = 0x80000000;
+            public const uint GenericWrite = 0x40000000;
+            public const uint FileShareRead = 0x00000001;
+            public const uint FileShareWrite = 0x00000002;
+            public const uint OpenExisting = 3;
+            public const int DIGCF_PRESENT = 0x02;
+            public const int DIGCF_DEVICEINTERFACE = 0x10;
+            public const int HIDP_STATUS_SUCCESS = unchecked((int)0x00110000);
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct SP_DEVICE_INTERFACE_DATA
+            {
+                public int cbSize;
+                public Guid InterfaceClassGuid;
+                public int Flags;
+                public IntPtr Reserved;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct HIDD_ATTRIBUTES
+            {
+                public int Size;
+                public ushort VendorID;
+                public ushort ProductID;
+                public ushort VersionNumber;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct HIDP_CAPS
+            {
+                public ushort Usage;
+                public ushort UsagePage;
+                public ushort InputReportByteLength;
+                public ushort OutputReportByteLength;
+                public ushort FeatureReportByteLength;
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 17)]
+                public ushort[] Reserved;
+                public ushort NumberLinkCollectionNodes;
+                public ushort NumberInputButtonCaps;
+                public ushort NumberInputValueCaps;
+                public ushort NumberInputDataIndices;
+                public ushort NumberOutputButtonCaps;
+                public ushort NumberOutputValueCaps;
+                public ushort NumberOutputDataIndices;
+                public ushort NumberFeatureButtonCaps;
+                public ushort NumberFeatureValueCaps;
+                public ushort NumberFeatureDataIndices;
+            }
+
+            [DllImport("hid.dll")]
+            public static extern void HidD_GetHidGuid(out Guid HidGuid);
+
+            [DllImport("hid.dll")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool HidD_GetAttributes(SafeFileHandle HidDeviceObject, ref HIDD_ATTRIBUTES Attributes);
+
+            [DllImport("hid.dll")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool HidD_GetPreparsedData(SafeFileHandle HidDeviceObject, out IntPtr PreparsedData);
+
+            [DllImport("hid.dll")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool HidD_FreePreparsedData(IntPtr PreparsedData);
+
+            [DllImport("hid.dll")]
+            public static extern int HidP_GetCaps(IntPtr PreparsedData, out HIDP_CAPS Capabilities);
+
+            [DllImport("setupapi.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern IntPtr SetupDiGetClassDevs(
+                ref Guid ClassGuid,
+                string Enumerator,
+                IntPtr hwndParent,
+                int Flags);
+
+            [DllImport("setupapi.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool SetupDiDestroyDeviceInfoList(IntPtr DeviceInfoSet);
+
+            [DllImport("setupapi.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool SetupDiEnumDeviceInterfaces(
+                IntPtr DeviceInfoSet,
+                IntPtr DeviceInfoData,
+                ref Guid InterfaceClassGuid,
+                int MemberIndex,
+                ref SP_DEVICE_INTERFACE_DATA DeviceInterfaceData);
+
+            [DllImport("setupapi.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool SetupDiGetDeviceInterfaceDetail(
+                IntPtr DeviceInfoSet,
+                ref SP_DEVICE_INTERFACE_DATA DeviceInterfaceData,
+                IntPtr DeviceInterfaceDetailData,
+                int DeviceInterfaceDetailDataSize,
+                out int RequiredSize,
+                IntPtr DeviceInfoData);
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern SafeFileHandle CreateFile(
+                string lpFileName,
+                uint dwDesiredAccess,
+                uint dwShareMode,
+                IntPtr lpSecurityAttributes,
+                uint dwCreationDisposition,
+                uint dwFlagsAndAttributes,
+                IntPtr hTemplateFile);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool WriteFile(
+                SafeFileHandle hFile,
+                byte[] lpBuffer,
+                uint nNumberOfBytesToWrite,
+                out uint lpNumberOfBytesWritten,
+                IntPtr lpOverlapped);
+        }
+    }
+}

--- a/IntifaceGameHapticsRouter/IntifaceGameHapticsRouter.csproj
+++ b/IntifaceGameHapticsRouter/IntifaceGameHapticsRouter.csproj
@@ -216,6 +216,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DualSenseRumble.cs" />
     <Compile Include="UWPInputMod.cs" />
     <Compile Include="EasyHookMod.cs" />
     <Compile Include="XInputMod.cs" />

--- a/IntifaceGameHapticsRouter/IntifaceGameHapticsRouterProperties.Designer.cs
+++ b/IntifaceGameHapticsRouter/IntifaceGameHapticsRouterProperties.Designer.cs
@@ -73,6 +73,30 @@ namespace IntifaceGameHapticsRouter {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int VibrationFadeMs {
+            get {
+                return ((int)(this["VibrationFadeMs"]));
+            }
+            set {
+                this["VibrationFadeMs"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DirectDualSenseRumble {
+            get {
+                return ((bool)(this["DirectDualSenseRumble"]));
+            }
+            set {
+                this["DirectDualSenseRumble"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool UseEmbedded {
             get {

--- a/IntifaceGameHapticsRouter/IntifaceGameHapticsRouterProperties.settings
+++ b/IntifaceGameHapticsRouter/IntifaceGameHapticsRouterProperties.settings
@@ -14,6 +14,12 @@
     <Setting Name="PacketTimingGapInMS" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">100</Value>
     </Setting>
+    <Setting Name="VibrationFadeMs" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="DirectDualSenseRumble" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="UseEmbedded" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/IntifaceGameHapticsRouter/MainWindow.xaml.cs
+++ b/IntifaceGameHapticsRouter/MainWindow.xaml.cs
@@ -23,10 +23,13 @@ namespace IntifaceGameHapticsRouter
         private double _baseline;
         private int _fadeMs;
         private double _currentOutput;
+        // Anchored at the most recent attack peak. Held constant across all fade ticks so the
+        // release ramp stays linear over _fadeMs regardless of intermediate target oscillations.
         private double _fadeStartLevel;
         private Task _updateTask;
         private readonly DualSenseRumble _dualSense = new DualSenseRumble();
-        private bool _directDualSenseRumbleEnabled;
+        // Read on the xinputTimer's ThreadPool thread, written on the WPF dispatcher thread.
+        private volatile bool _directDualSenseRumbleEnabled;
 
         public MainWindow()
         {
@@ -199,7 +202,14 @@ namespace IntifaceGameHapticsRouter
             var motorVal = (uint)(_currentOutput * 65535.0);
             _graphTab.UpdateVibrationValues(motorVal, motorVal);
 
-            Debug.WriteLine($"Updating XInput haptics to {_currentOutput}");
+            if (_directDualSenseRumbleEnabled && _dualSense.IsOpen)
+            {
+                var motor255 = (byte)Math.Min(255, (int)(_currentOutput * 255.0));
+                if (!_dualSense.SetRumble(motor255, motor255))
+                {
+                    _graphTab.SetDualSenseStatus("disconnected", false);
+                }
+            }
 
             // Keep ticking while we're still descending toward target.
             var stillFading = _currentOutput > target + 1e-6;
@@ -210,7 +220,7 @@ namespace IntifaceGameHapticsRouter
                 && _lastXInput.LeftMotor == 0
                 && _lastXInput.RightMotor == 0
                 && _baseline == 0
-                && _currentOutput == 0)
+                && _currentOutput <= 0.0)
             {
                 xinputTimer.Stop();
             }
@@ -226,16 +236,6 @@ namespace IntifaceGameHapticsRouter
                 _lastXInput = aMsg.XInputHaptics;
                 xinputTimer.Start();
                 _needXInputRecalc = true;
-
-                if (_directDualSenseRumbleEnabled)
-                {
-                    var strong = (byte)(aMsg.XInputHaptics.LeftMotor >> 8);
-                    var weak = (byte)(aMsg.XInputHaptics.RightMotor >> 8);
-                    if (!_dualSense.SetRumble(strong, weak) && _dualSense.IsOpen == false)
-                    {
-                        _graphTab.SetDualSenseStatus("disconnected", false);
-                    }
-                }
             }
             else if (aMsg.Log != null)
             {

--- a/IntifaceGameHapticsRouter/MainWindow.xaml.cs
+++ b/IntifaceGameHapticsRouter/MainWindow.xaml.cs
@@ -21,7 +21,12 @@ namespace IntifaceGameHapticsRouter
         private bool _needXInputRecalc;
         private double _multiplier;
         private double _baseline;
+        private int _fadeMs;
+        private double _currentOutput;
+        private double _fadeStartLevel;
         private Task _updateTask;
+        private readonly DualSenseRumble _dualSense = new DualSenseRumble();
+        private bool _directDualSenseRumbleEnabled;
 
         public MainWindow()
         {
@@ -53,8 +58,20 @@ namespace IntifaceGameHapticsRouter
             _graphTab.MultiplierChanged += OnMultiplierChanged;
             _graphTab.BaselineChanged += OnBaselineChanged;
             _graphTab.PacketGapChanged += OnPacketTimingChanged;
+            _graphTab.FadeMsChanged += OnFadeMsChanged;
+            _graphTab.DirectDualSenseRumbleChanged += OnDirectDualSenseRumbleChanged;
             _multiplier = _graphTab.Multiplier;
             _baseline = _graphTab.Baseline;
+            _fadeMs = _graphTab.FadeMs;
+            _directDualSenseRumbleEnabled = _graphTab.DirectDualSenseRumble;
+            if (_directDualSenseRumbleEnabled)
+            {
+                TryOpenDualSense();
+            }
+            else
+            {
+                _graphTab.SetDualSenseStatus("disabled", false);
+            }
             //_graphTab.PassthruChanged += PassthruChanged;
             _log.Info("Application started.");
             _updateTask = _aboutTab.CheckForUpdate();
@@ -68,6 +85,10 @@ namespace IntifaceGameHapticsRouter
         protected void OnProcessDetached(object aObj, EventArgs aNull)
         {
             _graphTab.StopUpdates();
+            if (_directDualSenseRumbleEnabled)
+            {
+                _dualSense.SetRumble(0, 0);
+            }
         }
 
         protected void OnMultiplierChanged(object aObj, double aValue)
@@ -92,6 +113,38 @@ namespace IntifaceGameHapticsRouter
             xinputTimer.Interval = IntifaceGameHapticsRouterProperties.Default.PacketTimingGapInMS;
         }
 
+        protected void OnFadeMsChanged(object o, int aValue)
+        {
+            _fadeMs = aValue;
+        }
+
+        protected void OnDirectDualSenseRumbleChanged(object o, bool enabled)
+        {
+            _directDualSenseRumbleEnabled = enabled;
+            if (enabled)
+            {
+                TryOpenDualSense();
+            }
+            else
+            {
+                _dualSense.SetRumble(0, 0);
+                _dualSense.Close();
+                _graphTab.SetDualSenseStatus("disabled", false);
+            }
+        }
+
+        private void TryOpenDualSense()
+        {
+            if (_dualSense.TryOpen())
+            {
+                _graphTab.SetDualSenseStatus("connected (USB)", true);
+            }
+            else
+            {
+                _graphTab.SetDualSenseStatus("not detected (USB-only prototype)", false);
+            }
+        }
+
         protected void OnLogMessage(object aObj, string aMsg)
         {
             _log.Info(aMsg);
@@ -109,26 +162,60 @@ namespace IntifaceGameHapticsRouter
             {
                 return;
             }
-            
-            // If we've received an off packet, just assume we won't be updating again until we get something new.
-            if (_lastXInput.LeftMotor == 0 && _lastXInput.RightMotor == 0 && _baseline == 0)
+
+            var averageVibeSpeed = (_lastXInput.LeftMotor + _lastXInput.RightMotor) / (2.0 * 65535.0);
+
+            // Target is the steady-state value the game/baseline is asking for.
+            // Floor at baseline so a fade naturally lands on the baseline level.
+            var target = Math.Min(Math.Max(averageVibeSpeed * _multiplier, _baseline), 1.0);
+
+            if (target >= _currentOutput)
+            {
+                // Snap up on attack — fade only applies on release.
+                _currentOutput = target;
+                _fadeStartLevel = target;
+            }
+            else if (_fadeMs <= 0)
+            {
+                _currentOutput = target;
+                _fadeStartLevel = target;
+            }
+            else
+            {
+                // Linear release from _fadeStartLevel to target over _fadeMs.
+                var tickMs = Math.Max(1, IntifaceGameHapticsRouterProperties.Default.PacketTimingGapInMS);
+                var span = _fadeStartLevel - target;
+                if (span > 0)
+                {
+                    var step = span * ((double)tickMs / _fadeMs);
+                    _currentOutput = Math.Max(target, _currentOutput - step);
+                }
+                else
+                {
+                    _currentOutput = target;
+                }
+            }
+
+            var motorVal = (uint)(_currentOutput * 65535.0);
+            _graphTab.UpdateVibrationValues(motorVal, motorVal);
+
+            Debug.WriteLine($"Updating XInput haptics to {_currentOutput}");
+
+            // Keep ticking while we're still descending toward target.
+            var stillFading = _currentOutput > target + 1e-6;
+            _needXInputRecalc = stillFading;
+
+            // Stop the timer only once we've fully settled with no input and no baseline.
+            if (!stillFading
+                && _lastXInput.LeftMotor == 0
+                && _lastXInput.RightMotor == 0
+                && _baseline == 0
+                && _currentOutput == 0)
             {
                 xinputTimer.Stop();
             }
 
-            _graphTab.UpdateVibrationValues(
-                Math.Max((uint)(_lastXInput.LeftMotor * _multiplier), (uint)(_baseline * 65535.0)),
-                Math.Max((uint)(_lastXInput.RightMotor * _multiplier), (uint)(_baseline * 65535.0)));
-
-            var averageVibeSpeed = (_lastXInput.LeftMotor + _lastXInput.RightMotor) / (2.0 * 65535.0);
-
-            // Calculate the vibe speed by first adding the multiplier to the averaged speed 
-            // Then check if it's above the baseline, if not default to the baseline
-            // If it is then make sure we don't go above 1.0 speed or things start breaking
-            var vibeSpeed = Math.Min(Math.Max(averageVibeSpeed * _multiplier, _baseline), 1.0);
-            Debug.WriteLine($"Updating XInput haptics to {vibeSpeed}");
-            _needXInputRecalc = false;
-            await Dispatcher.Invoke(async () => { await _intifaceTab.Vibrate((uint)_lastXInput.ControllerIndex, vibeSpeed); });
+            await Dispatcher.Invoke(async () => { await _intifaceTab.Vibrate((uint)_lastXInput.ControllerIndex, _currentOutput); });
         }
 
         protected void OnGVRMessageReceived(object aObj, GHRProtocolMessageContainer aMsg)
@@ -139,6 +226,16 @@ namespace IntifaceGameHapticsRouter
                 _lastXInput = aMsg.XInputHaptics;
                 xinputTimer.Start();
                 _needXInputRecalc = true;
+
+                if (_directDualSenseRumbleEnabled)
+                {
+                    var strong = (byte)(aMsg.XInputHaptics.LeftMotor >> 8);
+                    var weak = (byte)(aMsg.XInputHaptics.RightMotor >> 8);
+                    if (!_dualSense.SetRumble(strong, weak) && _dualSense.IsOpen == false)
+                    {
+                        _graphTab.SetDualSenseStatus("disconnected", false);
+                    }
+                }
             }
             else if (aMsg.Log != null)
             {

--- a/IntifaceGameHapticsRouter/VisualizerControl.xaml
+++ b/IntifaceGameHapticsRouter/VisualizerControl.xaml
@@ -20,6 +20,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <GroupBox Header="Vibration Multiplier" Grid.Row="0">
@@ -42,7 +43,17 @@
                     <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding ElementName=baselineSlider, Path=Value, StringFormat='P0'}" Height="16" Margin="15.333,0,14,0.333" Width="auto"></TextBlock>
                 </Grid>
             </GroupBox>
-            <GroupBox Header="Packet Timing Gap (In Milliseconds, 100ms default, make larger if toy is lagging)" Grid.Row="2">
+            <GroupBox Header="Fade To Baseline On Release (In Milliseconds, 0 = no fade)" Grid.Row="2">
+                <Grid Row="0" RenderTransformOrigin="0.841,0.517">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="auto"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <Slider x:Name="fadeSlider" Foreground="Black" Grid.Column="0" VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" TickPlacement="BottomRight" Minimum="0" Maximum="3000" TickFrequency="50" IsSnapToTickEnabled="False" Margin="0,2,0,1.667" ValueChanged="FadeSlider_OnValueChanged"/>
+                    <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding ElementName=fadeSlider, Path=Value, StringFormat='0'}" Height="16" Margin="15.333,0,14,0.333" Width="auto"></TextBlock>
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Packet Timing Gap (In Milliseconds, 100ms default, make larger if toy is lagging)" Grid.Row="3">
                 <Grid Row="0" RenderTransformOrigin="0.841,0.517">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"></ColumnDefinition>
@@ -52,13 +63,17 @@
                     <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding ElementName=packetGapSlider, Path=Value, StringFormat='0'}" Height="16" Margin="15.333,0,14,0.333" Width="auto"></TextBlock>
                 </Grid>
             </GroupBox>
-            <Grid Grid.Row="3">
+            <Grid Grid.Row="4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
                     <ColumnDefinition Width="*"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
                 </Grid.ColumnDefinitions>
-                <CheckBox Name="PassthruCheckBox" Grid.Column="0" Content="Pass Gamepad Rumble To Gamepad" IsChecked="True" HorizontalAlignment="Left" Margin="0,5,0,5" VerticalAlignment="Stretch" Checked="PassthruCheckBox_Changed" Unchecked="PassthruCheckBox_Changed" />
-                <Button Name="ResetSettings" Grid.Column="1" HorizontalAlignment="Right" Margin="0,2,0,1.667" Click="ResetSettings_Click">Reset Settings</Button>
+                <CheckBox Name="PassthruCheckBox" Grid.Column="0" Content="Pass Gamepad Rumble To Gamepad" IsChecked="True" HorizontalAlignment="Left" Margin="0,5,10,5" VerticalAlignment="Center" Checked="PassthruCheckBox_Changed" Unchecked="PassthruCheckBox_Changed" />
+                <CheckBox Name="DirectDualSenseCheckBox" Grid.Column="1" Content="Direct DualSense Rumble (HID, USB only)" HorizontalAlignment="Left" Margin="0,5,10,5" VerticalAlignment="Center" Checked="DirectDualSenseCheckBox_Changed" Unchecked="DirectDualSenseCheckBox_Changed" />
+                <TextBlock Name="DualSenseStatus" Grid.Column="2" VerticalAlignment="Center" Margin="0,5,10,5" Foreground="Gray" Text="DualSense: not detected" />
+                <Button Name="ResetSettings" Grid.Column="3" HorizontalAlignment="Right" Margin="0,2,0,1.667" Click="ResetSettings_Click">Reset Settings</Button>
             </Grid>
         </Grid>
         <wpf:CartesianChart Name="LowPowerChart" Grid.Row="1" Series="{Binding LowPowerSeriesCollection}" Background="Black" DisableAnimations="True"  Hoverable="False" DataTooltip="{x:Null}">

--- a/IntifaceGameHapticsRouter/VisualizerControl.xaml
+++ b/IntifaceGameHapticsRouter/VisualizerControl.xaml
@@ -49,7 +49,7 @@
                         <ColumnDefinition Width="*"></ColumnDefinition>
                         <ColumnDefinition Width="auto"></ColumnDefinition>
                     </Grid.ColumnDefinitions>
-                    <Slider x:Name="fadeSlider" Foreground="Black" Grid.Column="0" VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" TickPlacement="BottomRight" Minimum="0" Maximum="3000" TickFrequency="50" IsSnapToTickEnabled="False" Margin="0,2,0,1.667" ValueChanged="FadeSlider_OnValueChanged"/>
+                    <Slider x:Name="fadeSlider" Foreground="Black" Grid.Column="0" VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" TickPlacement="BottomRight" Minimum="0" Maximum="3000" TickFrequency="50" IsSnapToTickEnabled="False" Margin="0,2,0,1.667" ValueChanged="FadeSlider_OnValueChanged" Thumb.DragCompleted="FadeSlider_OnDragCompleted"/>
                     <TextBlock Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding ElementName=fadeSlider, Path=Value, StringFormat='0'}" Height="16" Margin="15.333,0,14,0.333" Width="auto"></TextBlock>
                 </Grid>
             </GroupBox>

--- a/IntifaceGameHapticsRouter/VisualizerControl.xaml.cs
+++ b/IntifaceGameHapticsRouter/VisualizerControl.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using LiveCharts;
 using LiveCharts.Wpf;
 using System.Text.RegularExpressions;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 
 namespace IntifaceGameHapticsRouter
@@ -163,8 +164,12 @@ namespace IntifaceGameHapticsRouter
         private void FadeSlider_OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             IntifaceGameHapticsRouterProperties.Default.VibrationFadeMs = FadeMs;
-            IntifaceGameHapticsRouterProperties.Default.Save();
             FadeMsChanged?.Invoke(this, FadeMs);
+        }
+
+        private void FadeSlider_OnDragCompleted(object sender, DragCompletedEventArgs e)
+        {
+            IntifaceGameHapticsRouterProperties.Default.Save();
         }
 
         private void DirectDualSenseCheckBox_Changed(object sender, RoutedEventArgs e)

--- a/IntifaceGameHapticsRouter/VisualizerControl.xaml.cs
+++ b/IntifaceGameHapticsRouter/VisualizerControl.xaml.cs
@@ -31,10 +31,14 @@ namespace IntifaceGameHapticsRouter
         public event EventHandler<double> MultiplierChanged;
         public event EventHandler<double> BaselineChanged;
         public event EventHandler<int> PacketGapChanged;
+        public event EventHandler<int> FadeMsChanged;
         public event EventHandler<bool> PassthruChanged;
+        public event EventHandler<bool> DirectDualSenseRumbleChanged;
 
         public double Multiplier => multiplierSlider.Value;
         public double Baseline => baselineSlider.Value;
+        public int FadeMs => (int)fadeSlider.Value;
+        public bool DirectDualSenseRumble => DirectDualSenseCheckBox.IsChecked == true;
 
         public VisualizerControl()
         {
@@ -49,6 +53,10 @@ namespace IntifaceGameHapticsRouter
                 IntifaceGameHapticsRouterProperties.Default.VibrationMultiplier = Multiplier;
                 IntifaceGameHapticsRouterProperties.Default.Save();
             };
+
+            fadeSlider.Value = IntifaceGameHapticsRouterProperties.Default.VibrationFadeMs;
+            DirectDualSenseCheckBox.IsChecked = IntifaceGameHapticsRouterProperties.Default.DirectDualSenseRumble;
+
             LowPowerValues = new ChartValues<double>();
             HighPowerValues = new ChartValues<double>();
             for (var i = 0; i < 200; ++i)
@@ -152,12 +160,43 @@ namespace IntifaceGameHapticsRouter
             PacketGapChanged?.Invoke(this, IntifaceGameHapticsRouterProperties.Default.PacketTimingGapInMS);
         }
 
+        private void FadeSlider_OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            IntifaceGameHapticsRouterProperties.Default.VibrationFadeMs = FadeMs;
+            IntifaceGameHapticsRouterProperties.Default.Save();
+            FadeMsChanged?.Invoke(this, FadeMs);
+        }
+
+        private void DirectDualSenseCheckBox_Changed(object sender, RoutedEventArgs e)
+        {
+            IntifaceGameHapticsRouterProperties.Default.DirectDualSenseRumble = DirectDualSenseRumble;
+            IntifaceGameHapticsRouterProperties.Default.Save();
+            DirectDualSenseRumbleChanged?.Invoke(this, DirectDualSenseRumble);
+        }
+
+        public void SetDualSenseStatus(string text, bool connected)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                DualSenseStatus.Text = "DualSense: " + text;
+                DualSenseStatus.Foreground = connected
+                    ? System.Windows.Media.Brushes.DarkGreen
+                    : System.Windows.Media.Brushes.Gray;
+            });
+        }
+
         private void ResetSettings_Click(object sender, RoutedEventArgs e)
         {
             IntifaceGameHapticsRouterProperties.Default.Reset();
             IntifaceGameHapticsRouterProperties.Default.Save();
+            multiplierSlider.Value = IntifaceGameHapticsRouterProperties.Default.VibrationMultiplier;
+            packetGapSlider.Value = IntifaceGameHapticsRouterProperties.Default.PacketTimingGapInMS;
+            fadeSlider.Value = IntifaceGameHapticsRouterProperties.Default.VibrationFadeMs;
+            DirectDualSenseCheckBox.IsChecked = IntifaceGameHapticsRouterProperties.Default.DirectDualSenseRumble;
             MultiplierChanged?.Invoke(this, IntifaceGameHapticsRouterProperties.Default.VibrationMultiplier);
             PacketGapChanged?.Invoke(this, IntifaceGameHapticsRouterProperties.Default.PacketTimingGapInMS);
+            FadeMsChanged?.Invoke(this, IntifaceGameHapticsRouterProperties.Default.VibrationFadeMs);
+            DirectDualSenseRumbleChanged?.Invoke(this, IntifaceGameHapticsRouterProperties.Default.DirectDualSenseRumble);
         }
     }
 }


### PR DESCRIPTION
# Add release-fade and direct DualSense rumble output

## Summary

Two new features for the XInput → toy pipeline, plus a small UI for both:

- **Release fade** — The direct 1 to 1 mapping of controller rumble to toy vibration can be a bit jarring to experience. I wanted to add a configurable fade-out so that when the controller stops rumbling, the toy fades from that point to the base rumble value

- **Direct DualSense rumble** — dualsense controllers don't have rumble passthrough because the steaminput translation layer doesn't work quite right. Added a checkbox that when toggled, will pass through the captured xinput rumble signal as direct HID signals to the controller.

Both settings persist across sessions. Fade is anchored at the most recent attack peak so the ramp duration stays linear and matches the slider's "ms" label.

## What changed

- `MainWindow.xaml.cs` — fade state machine in `OnXInputTimer`; DualSense write driven by the post-fade `_currentOutput` (same throttle as the rest of the pipeline); `volatile` flag for the cross-thread enable bit.
- `VisualizerControl.xaml{,.cs}` — new fade slider, "Direct DualSense Rumble" checkbox, and a status label ("connected (USB)" / "not detected" / "disconnected" / "disabled"). Fade slider persists on `DragCompleted` only, not on every tick.
- `DualSenseRumble.cs` (new) — USB-only HID writer. Enumerates via SetupAPI, distinguishes USB from BT by `HidP_GetCaps.OutputReportByteLength` (BT needs the `0x31` report with CRC32 — not implemented here, marked as prototype).
- `IntifaceGameHapticsRouterProperties` — two new persisted settings: `VibrationFadeMs` (int, default 0), `DirectDualSenseRumble` (bool, default false).

## Behavior notes

- **Fade is peak-anchored, not instantaneous-anchored.** If the game's target oscillates *below* the current output mid-fade, the ramp rate stays computed against the attack peak. This is what keeps the ramp linear over the requested ms; re-anchoring per tick would convert it to exponential decay (`new = current*(1-dt) + target*dt`) and the "ms" label would lie.
- **DualSense is USB-only this iteration.** Bluetooth DualSense uses a 547+ byte output report (`0x31`) gated by a CRC32 — supported in `DSAdvance` / `DualSenseX`, not here. BT support is a follow-up.
- **DualSense rumble is mono.** Both motors get the same `_currentOutput`-derived byte. `_currentOutput` is already the motor average, so reconstructing stereo from it would be lossy.

## Test plan

- [x] Fade slider at `0` ms: output snaps off on release (matches old behavior).
- [x] Fade slider at e.g. `1000` ms: visualizer chart shows a visible linear ramp-down on release.
- [x] Fade + non-zero baseline: ramp lands on baseline, not on zero.
- [x] Toggle "Direct DualSense Rumble" checkbox with controller connected over USB → status shows "connected (USB)", rumble fires in lockstep with visualizer.
- [x] Disconnect the controller mid-rumble → status flips to "disconnected", no crash, no spinning logs.
- [x] Re-connect and re-toggle the checkbox → reconnects cleanly.
- [x] Connect a DualSense over **Bluetooth** → status shows "not detected (USB-only prototype)", no crash.
- [x] Reset Settings restores both new defaults (fade=0, DirectDualSense=off) and reflects in the UI.
- [x] Settings persist across app restarts.

## Out of scope / follow-ups

- Bluetooth DualSense support (needs `0x31` report + CRC32).
- DualSense Edge has been included by PID but not bench-tested.
- Stereo DualSense rumble (would require routing `LeftMotor`/`RightMotor` separately through the fade pipeline instead of folding into `_currentOutput`).
- Adaptive triggers, lightbar, mic LED — the report byte layout supports them; this PR doesn't expose any UI for them.
